### PR TITLE
Fix placeholder patterns

### DIFF
--- a/src/main/java/co/aikar/advancementcommand/AdvancementCommand.java
+++ b/src/main/java/co/aikar/advancementcommand/AdvancementCommand.java
@@ -25,10 +25,10 @@ import java.util.regex.Pattern;
 public final class AdvancementCommand extends JavaPlugin implements Listener {
 
     private final ListMultimap<String, CommandInfo> commandMap = ArrayListMultimap.create();
-    private static final Pattern PLAYER = Pattern.compile("%player\b", Pattern.CASE_INSENSITIVE);
-    private static final Pattern PLAYER_DISPLAY = Pattern.compile("%playerdisplayname\b", Pattern.CASE_INSENSITIVE);
-    private static final Pattern UUID = Pattern.compile("%uuid\b", Pattern.CASE_INSENSITIVE);
-    private static final Pattern ADVANCEMENT = Pattern.compile("%advancement\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PLAYER = Pattern.compile("%player\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PLAYER_DISPLAY = Pattern.compile("%playerdisplayname\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern UUID = Pattern.compile("%uuid\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ADVANCEMENT = Pattern.compile("%advancement\\b", Pattern.CASE_INSENSITIVE);
 
     @Override
     public void onEnable() {


### PR DESCRIPTION
Hi Aikar,

I found that the user need to use `%player\b` to let the placeholder working correctly in v1.1.0:

```yaml
on_advancement:
  - advancement: minecraft:husbandry/plant_seed
    run_as: console
    command: "kill %player\b"
```

But obviously it's not what we expect.

The `\b` should be escape in quotes:

```java
Pattern.compile("%player\\b", Pattern.CASE_INSENSITIVE)
```

Please merge it if it's okay, thank you.